### PR TITLE
Users can recommend a television show

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,4 +1,4 @@
-.homes-show {
+.high_voltage-pages-show {
   .start-now {
     @include button;
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,10 @@ class ApplicationController < ActionController::Base
   include Monban::ControllerHelpers
 
   protect_from_forgery with: :exception
+
+  private
+
+  def signed_out?
+    !signed_in?
+  end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,9 @@
 class HomesController < ApplicationController
   def show
+    if signed_out?
+      render "pages/landing"
+    else
+      render :show
+    end
   end
 end

--- a/app/controllers/television_shows_controller.rb
+++ b/app/controllers/television_shows_controller.rb
@@ -1,0 +1,15 @@
+class TelevisionShowsController < ApplicationController
+  def create
+    television_show = TelevisionShow.new(television_show_params)
+
+    television_show.save
+
+    redirect_to root_path
+  end
+
+  private
+
+  def television_show_params
+    params.require(:television_show).permit(:title)
+  end
+end

--- a/app/models/television_show.rb
+++ b/app/models/television_show.rb
@@ -1,0 +1,3 @@
+class TelevisionShow < ActiveRecord::Base
+  validates :title, presence: true, uniqueness: true
+end

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,11 +1,10 @@
-<h1 class="logo">You should totally...</h1>
+<%= simple_form_for TelevisionShow.new do |form| %>
+  <%= form.input :title %>
+  <%= form.button :submit %>
+<% end %>
 
 <ul>
-  <li>...watch iZombie</li>
-  <li>...read The Martian</li>
-  <li>...learn Ruby</li>
+  <% TelevisionShow.all.each do |television_show| %>
+    <li><%= television_show.title %></li>
+  <% end %>
 </ul>
-
-<a class="start-now" href="<%= new_user_path %>">
-  <%= t(".start_now") %>
-</a>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,0 +1,11 @@
+<h1 class="logo">You should totally...</h1>
+
+<ul>
+  <li>...watch iZombie</li>
+  <li>...read The Martian</li>
+  <li>...learn Ruby</li>
+</ul>
+
+<a class="start-now" href="<%= new_user_path %>">
+  <%= t(".start_now") %>
+</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,8 @@ en:
 
   helpers:
     submit:
+      television_show:
+        create: Totally Recommend This
       user:
         create: Sign up
 
@@ -27,6 +29,6 @@ en:
     application:
       sign_out: Sign out
 
-  homes:
-    show:
+  pages:
+    landing:
       start_now: Totally start now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resource :session, only: [:new, :create, :destroy]
   resources :users, only: [:new, :create]
+  resources :television_shows, only: [:create]
 
   root "homes#show"
 end

--- a/db/migrate/20160116222402_create_television_shows.rb
+++ b/db/migrate/20160116222402_create_television_shows.rb
@@ -1,0 +1,11 @@
+class CreateTelevisionShows < ActiveRecord::Migration
+  def change
+    create_table :television_shows do |t|
+      t.string :title, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :television_shows, :title, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160116202139) do
+ActiveRecord::Schema.define(version: 20160116222402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "television_shows", force: :cascade do |t|
+    t.string   "title",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "television_shows", ["title"], name: "index_television_shows_on_title", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",           null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,8 @@
 FactoryGirl.define do
+  factory :television_show do
+    sequence(:title) { |n| "Show #{n}" }
+  end
+
   factory :user do
     sequence(:email) { |n| "email#{n}@example.com" }
     password_digest "password"

--- a/spec/features/user_makes_a_recommendation_spec.rb
+++ b/spec/features/user_makes_a_recommendation_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+feature "A User makes a recommendation" do
+  scenario "and sees it on their profile" do
+    user = create(:user)
+    sign_in(user)
+    title = "Breaking Bad"
+
+    visit root_path
+    fill_form_and_submit :television_show, title: title
+
+    expect(page).to have_text(title)
+  end
+end

--- a/spec/features/visitor_signs_up_spec.rb
+++ b/spec/features/visitor_signs_up_spec.rb
@@ -4,7 +4,7 @@ feature "Visitor signs up" do
   scenario "successfully" do
     visit root_path
 
-    click_on t("homes.show.start_now")
+    click_on t("pages.landing.start_now")
     fill_form_and_submit :user,
       email: "ann_e_body@example.com",
       password: "password"

--- a/spec/models/television_show_spec.rb
+++ b/spec/models/television_show_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe TelevisionShow do
+  it { is_expected.to validate_presence_of(:title) }
+
+  context "uniqueness" do
+    before { create(:television_show) }
+
+    it { is_expected.to validate_uniqueness_of(:title) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,11 +12,18 @@ module Features
   include Formulaic::Dsl
 end
 
+Monban.test_mode!
+
 RSpec.configure do |config|
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+  config.include Monban::Test::Helpers, type: :feature
+
+  config.after :each do
+    Monban.test_reset!
+  end
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
Reason for change:
- Allow users to recommend television shows

What the change was:
- When logged out, guests should see the landing page (`pages/landing`)
- When logged in, users see the form to add a favorite TV show.
- Add `TelevisionShow` model, resources etc. to store them.
- Tests.
