### PR TITLE
Remove unit tests for ActiveRecord associations

### DIFF
--- a/spec/models/recommended_item_spec.rb
+++ b/spec/models/recommended_item_spec.rb
@@ -1,4 +1,0 @@
-require "rails_helper"
-
-RSpec.describe RecommendedItem do
-end

--- a/spec/models/recommended_item_spec.rb
+++ b/spec/models/recommended_item_spec.rb
@@ -1,6 +1,4 @@
 require "rails_helper"
 
 RSpec.describe RecommendedItem do
-  it { is_expected.to belong_to(:television_show) }
-  it { is_expected.to belong_to(:user) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,11 +14,6 @@ RSpec.describe User do
     end
   end
 
-  context "associations" do
-    it { is_expected.to have_many(:recommended_items) }
-    it { is_expected.to have_many(:television_shows) }
-  end
-
   context "#recommend" do
     it "adds a television show to a user's recommendations" do
       television_show = create(:television_show)


### PR DESCRIPTION
- When associations work, feature specs pass. When they don't, feature specs crash spectacularly. It's difficult to accidentally write a feature spec that passes when associations are incorrect. Thus, remove unit tests for associations.
- In contrast, validations can easily be missing when feature specs pass. Testing validations at the feature level is slow and error-prone. Thus, keep the unit tests for validations.
