### PR TITLE
Homepage only shows recommendations from followees

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -6,4 +6,12 @@
       color: $light-gray;
     }
   }
+
+  .no-followers {
+    margin-bottom: $base-spacing;
+  }
+
+  h2 {
+    font-size: $base-font-size * 2;
+  }
 }

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,7 +3,8 @@ class HomesController < ApplicationController
     if signed_out?
       render "pages/landing"
     else
-      @recommended_items = RecommendedItem.all
+      @recommended_items = RecommendedItem.where(user: current_user.with_following)
+
       render :show
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,15 +5,25 @@ class User < ActiveRecord::Base
 
   has_many :recommended_items
   has_many :television_shows, through: :recommended_items
-
   has_many :following_relationships,
     class_name: "Relationship", foreign_key: :follower_id
   has_many :following, through: :following_relationships, source: :followed
+  has_many :follower_relationships,
+    class_name: "Relationship", foreign_key: :followed_id
+  has_many :followers, through: :follower_relationships, foreign_key: :follower
+
+  def users_to_follow
+    self.class.where.not(id: self).first(3)
+  end
 
   def recommend(television_show)
     unless television_shows.include?(television_show)
       television_shows << television_show
     end
+  end
+
+  def with_following
+    [self] + following
   end
 
   def follow(user)

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -3,6 +3,18 @@
   <%= form.button :submit %>
 <% end %>
 
+<% if current_user.following.empty? %>
+  <div class="no-followers">
+    <p><%= t(".not_following_anyone") %></p>
+    <ul>
+      <% current_user.users_to_follow.each do |user| %>
+        <li><%= link_to user.username, user %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<h2>Recommendations</h2>
 <ul>
   <% @recommended_items.each do |recommended_item| %>
     <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,10 @@ en:
     landing:
       start_now: Totally start now
 
+  homes:
+    show:
+      not_following_anyone: "Looks like you're not following anyone. Here are some suggestions:"
+
   television_shows:
     create:
       cannot_recommend_twice: Nice rec! But you already recommended this show :/

--- a/spec/features/user_makes_a_recommendation_spec.rb
+++ b/spec/features/user_makes_a_recommendation_spec.rb
@@ -32,8 +32,8 @@ feature "A User makes a recommendation" do
     user = create(:user)
     user.recommend(television_show)
     other_user = create(:user)
-    sign_in(other_user)
 
+    sign_in(other_user)
     visit root_path
     fill_form_and_submit :television_show, title: title
 

--- a/spec/features/user_views_feed_spec.rb
+++ b/spec/features/user_views_feed_spec.rb
@@ -6,11 +6,50 @@ feature "A User views their feed" do
     recommended_item = create(:recommended_item)
     recommending_user = recommended_item.user
     television_show = recommended_item.television_show
+    user.follow(recommending_user)
 
     sign_in(user)
     visit root_path
 
     expect(page).to have_text(television_show.title)
     expect(page).to have_text(recommending_user.username)
+  end
+
+  scenario "and sees recommendations only from people they follow" do
+    user = create(:user)
+    followee = create(:user)
+    follower = create(:user)
+    followee_television_show = create(:television_show)
+    follower_television_show = create(:television_show)
+    followee.recommend(followee_television_show)
+    follower.recommend(follower_television_show)
+    user.follow(followee)
+
+    sign_in(user)
+    visit root_path
+
+    expect(page).to have_text(followee_television_show.title)
+    expect(page).not_to have_text(follower_television_show.title)
+  end
+
+  context "when user is not following anybody" do
+    scenario "and sees some suggested people to follow" do
+      user = create(:user)
+      suggested_users = create_list(:user, 3)
+      not_suggested_user = create(:user)
+
+      sign_in(user)
+      visit root_path
+
+      expect(page).to have_text t("homes.show.not_following_anyone")
+      suggested_users.each do |suggested_user|
+        expect(page).to have_link(
+          suggested_user.username,
+          href: user_path(suggested_user),
+        )
+      end
+      expect(page).not_to have_text not_suggested_user.username
+      expect(page).not_to have_text user.username
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe User do
     end
   end
 
+  context "#users_to_follow" do
+    it "returns the first 3 users, excluding the current user" do
+      user = create(:user)
+      recommended = create_list(:user, 3)
+      _not_recommended = create(:user)
+
+      result = user.users_to_follow
+
+      expect(result).to eq recommended
+    end
+  end
+
   context "#recommend" do
     it "adds a television show to a user's recommendations" do
       television_show = create(:television_show)
@@ -78,6 +90,27 @@ RSpec.describe User do
       stranger = create(:user)
 
       expect(user).not_to be_following stranger
+    end
+  end
+
+  context "#with_following" do
+    it "returns the user and the users they are following" do
+      user = create(:user)
+      following = create(:user)
+      user.follow(following)
+
+      result = user.with_following
+
+      expect(result).to match_array [user, following]
+    end
+
+    it "does not return unfollowed users" do
+      user = create(:user)
+      not_following = create(:user)
+
+      result = user.with_following
+
+      expect(result).not_to include not_following
     end
   end
 end


### PR DESCRIPTION
Instead of showing all recommendations across the whole site, only show
recommendations from people the current user is following.

Since that means their homepage is empty at first, suggest some people to
follow.

https://trello.com/c/UepXXZ9k
