### PR TITLE
Use Monban's backdoor in tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,6 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "www.example.com" }
   config.active_job.queue_adapter = :inline
+
+  config.middleware.insert_after Warden::Manager, Monban::BackDoor
 end

--- a/spec/features/user_follows_and_unfollows_another_user_spec.rb
+++ b/spec/features/user_follows_and_unfollows_another_user_spec.rb
@@ -4,9 +4,8 @@ feature "A User follows another user" do
   scenario "and the current user sees that they follow the other user" do
     follower = create(:user)
     followed = create(:user)
-    sign_in(follower)
 
-    visit user_path(followed)
+    visit user_path(followed, as: follower)
     click_on t("users.show.follow")
 
     expect(page).to have_button_with_text(t("users.show.unfollow"))
@@ -15,9 +14,8 @@ feature "A User follows another user" do
   scenario "and then unfollows the followed user" do
     follower = create(:user)
     followed = create(:user)
-    sign_in(follower)
 
-    visit user_path(followed)
+    visit user_path(followed, as: follower)
     click_on t("users.show.follow")
     click_on t("users.show.unfollow")
 

--- a/spec/features/user_makes_a_recommendation_spec.rb
+++ b/spec/features/user_makes_a_recommendation_spec.rb
@@ -4,9 +4,8 @@ feature "A User makes a recommendation" do
   scenario "and sees it on their profile" do
     title = "Breaking Bad"
     user = create(:user)
-    sign_in(user)
 
-    visit root_path
+    visit root_path(as: user)
     fill_form_and_submit :television_show, title: title
     click_on t("application.header.my_profile")
 
@@ -16,9 +15,8 @@ feature "A User makes a recommendation" do
   scenario "and cannot recommend the same show twice" do
     title = "Breaking Bad"
     user = create(:user)
-    sign_in(user)
 
-    visit root_path
+    visit root_path(as: user)
     2.times do
       fill_form_and_submit :television_show, title: title
     end
@@ -33,8 +31,7 @@ feature "A User makes a recommendation" do
     user.recommend(television_show)
     other_user = create(:user)
 
-    sign_in(other_user)
-    visit root_path
+    visit root_path(as: other_user)
     fill_form_and_submit :television_show, title: title
 
     expect(page).to have_text title

--- a/spec/features/user_views_feed_spec.rb
+++ b/spec/features/user_views_feed_spec.rb
@@ -8,8 +8,7 @@ feature "A User views their feed" do
     television_show = recommended_item.television_show
     user.follow(recommending_user)
 
-    sign_in(user)
-    visit root_path
+    visit root_path(as: user)
 
     expect(page).to have_text(television_show.title)
     expect(page).to have_text(recommending_user.username)
@@ -25,8 +24,7 @@ feature "A User views their feed" do
     follower.recommend(follower_television_show)
     user.follow(followee)
 
-    sign_in(user)
-    visit root_path
+    visit root_path(as: user)
 
     expect(page).to have_text(followee_television_show.title)
     expect(page).not_to have_text(follower_television_show.title)
@@ -38,8 +36,7 @@ feature "A User views their feed" do
       suggested_users = create_list(:user, 3)
       not_suggested_user = create(:user)
 
-      sign_in(user)
-      visit root_path
+      visit root_path(as: user)
 
       expect(page).to have_text t("homes.show.not_following_anyone")
       suggested_users.each do |suggested_user|


### PR DESCRIPTION
Instead of `sign_in(user)`, we can do `visit root_path(as: user)`, which will sign that user in automatically.

Docs: https://github.com/halogenandtoast/monban#monban-backdoor
