### PR TITLE
Design: divide things into sections, add color

### DIFF
--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -20,6 +20,9 @@ $blue: #477dca;
 $dark-gray: #333;
 $medium-gray: #999;
 $light-gray: #ddd;
+$white: #fff;
+$orange: #c87f1e;
+$accent-color: $orange;
 
 // Font Colors
 $base-font-color: $dark-gray;

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -1,9 +1,15 @@
 header {
-  background-color: $light-gray;
+  background-color: $accent-color;
+  color: $white;
   float: right;
+  font-weight: bold;
   margin-bottom: $base-spacing;
   padding: $small-spacing;
   width: 100%;
+
+  a {
+    color: $white;
+  }
 }
 
 .header__items {
@@ -13,8 +19,8 @@ header {
   .header__item {
     display: inline;
 
-    &:not(:last-child):after {
-      content: "|";
+    &:not(:last-child) {
+      margin-right: $base-spacing;
     }
   }
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -7,8 +7,21 @@
     }
   }
 
-  .no-followers {
+  form {
     margin-bottom: $base-spacing;
+  }
+
+  aside {
+    @include span-columns(3);
+    margin-left: $column;
+  }
+
+  main {
+    @include span-columns(8);
+
+    li {
+      margin-bottom: $base-spacing;
+    }
   }
 
   h2 {

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,25 +1,31 @@
-<%= simple_form_for TelevisionShow.new do |form| %>
-  <%= form.input :title %>
-  <%= form.button :submit %>
-<% end %>
-
-<% if current_user.following.empty? %>
-  <div class="no-followers">
-    <p><%= t(".not_following_anyone") %></p>
-    <ul>
-      <% current_user.users_to_follow.each do |user| %>
-        <li><%= link_to user.username, user %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
-<h2>Recommendations</h2>
-<ul>
-  <% @recommended_items.each do |recommended_item| %>
-    <li>
-      <%= recommended_item.television_show_title %>
-      &mdash; <%= link_to recommended_item.username, recommended_item.user %>
-    </li>
+<main>
+  <h2>Recommendations</h2>
+  <%= simple_form_for TelevisionShow.new do |form| %>
+    <%= form.input :title, label: false %>
+    <%= form.button :submit %>
   <% end %>
-</ul>
+
+  <ul>
+    <% @recommended_items.each do |recommended_item| %>
+      <li>
+        <strong>
+          <%= recommended_item.television_show_title %>
+        </strong>
+        &mdash; <%= link_to recommended_item.username, recommended_item.user %>
+      </li>
+    <% end %>
+  </ul>
+</main>
+
+<aside>
+  <% if current_user.following.empty? %>
+    <div>
+      <p><%= t(".not_following_anyone") %></p>
+      <ul>
+        <% current_user.users_to_follow.each do |user| %>
+          <li><%= link_to user.username, user %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</aside>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,6 @@
 
   <%= render "header" %>
 
-
   <div id="container">
     <%= yield %>
   </div>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -10,6 +10,9 @@ en:
       # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
+    placeholders:
+      television_show:
+        title: New Girl
     # Examples
     # labels:
     #   defaults:
@@ -19,8 +22,6 @@ en:
     #       email: 'E-mail to sign in.'
     #     edit:
     #       email: 'E-mail.'
-    # hints:
-    #   defaults:
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'
     # include_blanks:

--- a/spec/features/user_makes_a_recommendation_spec.rb
+++ b/spec/features/user_makes_a_recommendation_spec.rb
@@ -6,7 +6,7 @@ feature "A User makes a recommendation" do
     user = create(:user)
 
     visit root_path(as: user)
-    fill_form_and_submit :television_show, title: title
+    recommend_television_show(title)
     click_on t("application.header.my_profile")
 
     expect(page).to have_text(title)
@@ -18,7 +18,7 @@ feature "A User makes a recommendation" do
 
     visit root_path(as: user)
     2.times do
-      fill_form_and_submit :television_show, title: title
+      recommend_television_show(title)
     end
 
     expect(page).to have_text t("television_shows.create.cannot_recommend_twice")
@@ -32,8 +32,13 @@ feature "A User makes a recommendation" do
     other_user = create(:user)
 
     visit root_path(as: other_user)
-    fill_form_and_submit :television_show, title: title
+    recommend_television_show(title)
 
     expect(page).to have_text title
+  end
+
+  def recommend_television_show(title)
+    fill_in :television_show_title, with: title
+    click_on submit(:television_show)
   end
 end


### PR DESCRIPTION
- Introduce our Trello board's background color as the `$accent-color` #tbt
- Use a two-column layout on the home page, with the recommendations feed taking up most of the space and recommended people to follow on the right.
- Add more whitespace all over.

---

Before:

![youshouldtotally 2016-01-24 18-32-17](https://cloud.githubusercontent.com/assets/257678/12541225/cf762590-c2c8-11e5-889c-c75e1ee212a0.png)

---

After:

![youshouldtotally 2016-01-24 18-33-47](https://cloud.githubusercontent.com/assets/257678/12541239/04f63c1e-c2c9-11e5-8c32-7a2b3f66aac3.png)
